### PR TITLE
Fix duplicated fixture primary key

### DIFF
--- a/src/locality/fixtures/locality.json
+++ b/src/locality/fixtures/locality.json
@@ -1,6 +1,6 @@
 [
 	{	"model": "locality.country",
-		"pk": 4,
+		"pk": 906,
 		"fields": {
 			"iso2": "AF",
 			"iso3": "AFG",


### PR DESCRIPTION
Currently the included fixture can't be loaded because of a duplicate primary key ID